### PR TITLE
docs: Add format shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 El repositorio contiene, en este `README.md`, una tabla que enumera la mayoría de atajos de teclado (_shortcuts_, _keybindings_) que uso en mi día a día entre `Visual Studio Code`, `Rider` y `Xcode`. Cuando es posible, aparecen en la misma línea aquellos que son similares o realizan funciones parecidas.
 
-| Acción                          | Visual Studio Code | Xcode                          | Rider | Visual Studio |
-| ------------------------------- | ------------------ | ------------------------------ | ----- | ------------- |
-| Run Playground                  | N/A                | `command` + `shift` + `return` | N/A   | N/A           |
-| Format File with 'swift-format' | N/A                | `control` + `shift` + `I`      | N/A   | N/A           |
+| Acción                                            | Visual Studio Code      | Xcode                          | Rider | Visual Studio |
+| ------------------------------------------------- | ----------------------- | ------------------------------ | ----- | ------------- |
+| Run Playground                                    | N/A                     | `command` + `shift` + `return` | N/A   | N/A           |
+| Format Document / Format File with 'swift-format' | `shift`+ `option` + `F` | `control` + `shift` + `I`      | ?     | ?             |


### PR DESCRIPTION
It adds the `Format Document` shortcut on VS Code.